### PR TITLE
removed '-ce' from docker version name check

### DIFF
--- a/dockerfix
+++ b/dockerfix
@@ -151,7 +151,7 @@ semver_comparison () {
 
 docker_version_check () {
   docker_local_version=$(docker info --format '{{ .ServerVersion }}')
-  docker_remote_version=$(curl -s https://download.docker.com/mac/static/stable/x86_64/ | grep -o "docker-.*-ce" | perl -pe 'if(($_)=/([0-9]+([.][0-9]+)+)/){$_.="\n"}' | sort -rV | head -1)
+  docker_remote_version=$(curl -s https://download.docker.com/mac/static/stable/x86_64/ | grep -o "docker-.*" | perl -pe 'if(($_)=/([0-9]+([.][0-9]+)+)/){$_.="\n"}' | sort -rV | head -1)
   text_format_yellow "Checking for docker updates.." && echo
   text_format_green "> " && text_format_yellow "Docker version $docker_remote_version is the latest stable ce version currently available" && echo 
   text_format_green "> " && text_format_yellow "Docker version $docker_local_version is currently installed" && echo


### PR DESCRIPTION
Noticed that the docker version check didn't seem to be right:

`Checking for docker updates..
> Docker version 18.06.3 is the latest stable ce version currently available
> Docker version 19.03.8 is currently installed`

Checking https://download.docker.com/mac/static/stable/x86_64/, looks like they dropped `-ce` from the file name from releases after 18.06.3, made a small fix which should resole the issue.